### PR TITLE
expose set_configuration

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -107,6 +107,9 @@ Parameter `data_or_length` can be a integer length for an IN transfer, or a Buff
 
 The `data` parameter of the callback is always undefined for OUT transfers, or will be passed a Buffer for IN transfers.
 
+### .setConfiguration(id, callback(error))
+Set the device configuration to something other than the default (0). To use this, first call `.open(false)` (which tells it not to auto configure), then before claiming an interface, call this method.
+
 ### .getStringDescriptor(index, callback(error, data))
 Perform a control transfer to retrieve a string descriptor
 

--- a/package.json
+++ b/package.json
@@ -46,8 +46,8 @@
     "remote_path": "./pre-gyp/{name}/v{version}"
   },
   "dependencies": {
-    "node-pre-gyp": "git+https://github.com/mapbox/node-pre-gyp.git#c88d6a04",
-    "nan": "^1.6.0"
+    "nan": "^2.0.9",
+    "node-pre-gyp": "git+https://github.com/mapbox/node-pre-gyp.git#c88d6a04"
   },
   "bundledDependencies": [
     "node-pre-gyp"

--- a/src/device.cc
+++ b/src/device.cc
@@ -2,17 +2,17 @@
 #include <string.h>
 
 #define STRUCT_TO_V8(TARGET, STR, NAME) \
-		TARGET->ForceSet(V8STR(#NAME), NanNew<Uint32>((uint32_t) (STR).NAME), CONST_PROP);
+		TARGET->ForceSet(V8STR(#NAME), Nan::New<Uint32>((uint32_t) (STR).NAME), CONST_PROP);
 
 #define CHECK_OPEN() \
 		if (!self->device_handle){THROW_ERROR("Device is not opened");}
 
 #define MAX_PORTS 7
 
-static v8::Persistent<v8::FunctionTemplate> device_constructor;
+static Nan::Persistent<v8::FunctionTemplate> device_constructor;
 
-Handle<Object> makeBuffer(const unsigned char* ptr, unsigned length) {
-	return NanNewBufferHandle((char*) ptr, (uint32_t) length);
+Local<Object> makeBuffer(const unsigned char* ptr, unsigned length) {
+	return Nan::NewBuffer((char*) ptr, (uint32_t) length).ToLocalChecked();
 }
 
 Device::Device(libusb_device* d): device(d), device_handle(0) {
@@ -28,25 +28,28 @@ Device::~Device(){
 }
 
 // Map pinning each libusb_device to a particular V8 instance
-std::map<libusb_device*, _NanWeakCallbackInfo<Value, libusb_device>*> Device::byPtr;
+std::map<libusb_device*, DeviceObject*> Device::byPtr;
 
-NAN_WEAK_CALLBACK(DeviceWeakCallback) {
+void DeviceWeakCallback(const Nan::WeakCallbackInfo<libusb_device> &data)  {
 	Device::unpin(data.GetParameter());
 }
 
 // Get a V8 instance for a libusb_device: either the existing one from the map,
 // or create a new one and add it to the map.
-Handle<Value> Device::get(libusb_device* dev){
+Local<Object> Device::get(libusb_device* dev){
 	auto it = byPtr.find(dev);
 	if (it != byPtr.end()){
-		return NanNew(it->second->persistent);
-	}else{
-		Local<FunctionTemplate> constructorHandle = NanNew<v8::FunctionTemplate>(device_constructor);
-		v8::Handle<v8::Value> argv[1] = { EXTERNAL_NEW(new Device(dev)) };
-		Handle<Value> v = constructorHandle->GetFunction()->NewInstance(1, argv);
-		auto p = NanMakeWeakPersistent(v, dev, DeviceWeakCallback);
-		byPtr.insert(std::make_pair(dev, p));
-		return v;
+		return Nan::New(it->second->obj);
+	} else {
+		Local<FunctionTemplate> constructorHandle = Nan::New<v8::FunctionTemplate>(device_constructor);
+		Local<Value> argv[1] = { EXTERNAL_NEW(new Device(dev)) };
+		Local<Object> obj = constructorHandle->GetFunction()->NewInstance(1, argv);
+		Nan::Persistent<Object> p(obj);
+		DeviceObject* dd = new DeviceObject;
+		dd->obj.Reset(p);
+		p.SetWeak(dev, DeviceWeakCallback, Nan::WeakCallbackType::kParameter);
+		byPtr.insert(std::make_pair(dev, dd));
+		return obj;
 	}
 }
 
@@ -58,13 +61,13 @@ void Device::unpin(libusb_device* device) {
 static NAN_METHOD(deviceConstructor) {
 	ENTER_CONSTRUCTOR_POINTER(Device, 1);
 
-	args.This()->ForceSet(V8SYM("busNumber"),
-		NanNew<Uint32>((uint32_t) libusb_get_bus_number(self->device)), CONST_PROP);
-	args.This()->ForceSet(V8SYM("deviceAddress"),
-		NanNew<Uint32>((uint32_t) libusb_get_device_address(self->device)), CONST_PROP);
+	info.This()->ForceSet(V8SYM("busNumber"),
+		Nan::New<Uint32>((uint32_t) libusb_get_bus_number(self->device)), CONST_PROP);
+	info.This()->ForceSet(V8SYM("deviceAddress"),
+		Nan::New<Uint32>((uint32_t) libusb_get_device_address(self->device)), CONST_PROP);
 
-	Local<Object> v8dd = NanNew<Object>();
-	args.This()->ForceSet(V8SYM("deviceDescriptor"), v8dd, CONST_PROP);
+	Local<Object> v8dd = Nan::New<Object>();
+	info.This()->ForceSet(V8SYM("deviceDescriptor"), v8dd, CONST_PROP);
 
 	struct libusb_device_descriptor dd;
 	CHECK_USB(libusb_get_device_descriptor(self->device, &dd));
@@ -87,14 +90,14 @@ static NAN_METHOD(deviceConstructor) {
 	uint8_t port_numbers[MAX_PORTS];
 	int ret = libusb_get_port_numbers(self->device, &port_numbers[0], MAX_PORTS);
 	CHECK_USB(ret);
-	Local<Array> array = NanNew<Array>(ret);
+	Local<Array> array = Nan::New<Array>(ret);
 	for (int i = 0; i < ret; ++ i) {
-		array->Set(i, NanNew(port_numbers[i]));
+		array->Set(i, Nan::New(port_numbers[i]));
 	}
 
-	args.This()->ForceSet(V8SYM("portNumbers"), array, CONST_PROP);
+	info.This()->ForceSet(V8SYM("portNumbers"), array, CONST_PROP);
 
-	NanReturnValue(args.This());
+	info.GetReturnValue().Set(info.This());
 }
 
 NAN_METHOD(Device_GetConfigDescriptor) {
@@ -103,7 +106,7 @@ NAN_METHOD(Device_GetConfigDescriptor) {
 	libusb_config_descriptor* cdesc;
 	CHECK_USB(libusb_get_active_config_descriptor(self->device, &cdesc));
 
-	Local<Object> v8cdesc = NanNew<Object>();
+	Local<Object> v8cdesc = Nan::New<Object>();
 
 	STRUCT_TO_V8(v8cdesc, *cdesc, bLength)
 	STRUCT_TO_V8(v8cdesc, *cdesc, bDescriptorType)
@@ -113,24 +116,24 @@ NAN_METHOD(Device_GetConfigDescriptor) {
 	STRUCT_TO_V8(v8cdesc, *cdesc, iConfiguration)
 	STRUCT_TO_V8(v8cdesc, *cdesc, bmAttributes)
 	// Libusb 1.0 typo'd bMaxPower as MaxPower
-	v8cdesc->ForceSet(V8STR("bMaxPower"), NanNew<Uint32>((uint32_t) cdesc->MaxPower), CONST_PROP);
+	v8cdesc->ForceSet(V8STR("bMaxPower"), Nan::New<Uint32>((uint32_t) cdesc->MaxPower), CONST_PROP);
 
 	v8cdesc->ForceSet(V8SYM("extra"), makeBuffer(cdesc->extra, cdesc->extra_length), CONST_PROP);
 
-	Local<Array> v8interfaces = NanNew<Array>(cdesc->bNumInterfaces);
+	Local<Array> v8interfaces = Nan::New<Array>(cdesc->bNumInterfaces);
 	v8cdesc->ForceSet(V8SYM("interfaces"), v8interfaces);
 
 	for (int idxInterface = 0; idxInterface < cdesc->bNumInterfaces; idxInterface++) {
 		int numAltSettings = cdesc->interface[idxInterface].num_altsetting;
 
-		Local<Array> v8altsettings = NanNew<Array>(numAltSettings);
+		Local<Array> v8altsettings = Nan::New<Array>(numAltSettings);
 		v8interfaces->Set(idxInterface, v8altsettings);
 
 		for (int idxAltSetting = 0; idxAltSetting < numAltSettings; idxAltSetting++) {
 			const libusb_interface_descriptor& idesc =
 				cdesc->interface[idxInterface].altsetting[idxAltSetting];
 
-			Local<Object> v8idesc = NanNew<Object>();
+			Local<Object> v8idesc = Nan::New<Object>();
 			v8altsettings->Set(idxAltSetting, v8idesc);
 
 			STRUCT_TO_V8(v8idesc, idesc, bLength)
@@ -145,12 +148,12 @@ NAN_METHOD(Device_GetConfigDescriptor) {
 
 			v8idesc->ForceSet(V8SYM("extra"), makeBuffer(idesc.extra, idesc.extra_length), CONST_PROP);
 
-			Local<Array> v8endpoints = NanNew<Array>(idesc.bNumEndpoints);
+			Local<Array> v8endpoints = Nan::New<Array>(idesc.bNumEndpoints);
 			v8idesc->ForceSet(V8SYM("endpoints"), v8endpoints, CONST_PROP);
 			for (int idxEndpoint = 0; idxEndpoint < idesc.bNumEndpoints; idxEndpoint++){
 				const libusb_endpoint_descriptor& edesc = idesc.endpoint[idxEndpoint];
 
-				Local<Object> v8edesc = NanNew<Object>();
+				Local<Object> v8edesc = Nan::New<Object>();
 				v8endpoints->Set(idxEndpoint, v8edesc);
 
 				STRUCT_TO_V8(v8edesc, edesc, bLength)
@@ -168,7 +171,7 @@ NAN_METHOD(Device_GetConfigDescriptor) {
 	}
 
 	libusb_free_config_descriptor(cdesc);
-	NanReturnValue(v8cdesc);
+	info.GetReturnValue().Set(v8cdesc);
 }
 
 NAN_METHOD(Device_Open) {
@@ -176,7 +179,7 @@ NAN_METHOD(Device_Open) {
 	if (!self->device_handle){
 		CHECK_USB(libusb_open(self->device, &self->device_handle));
 	}
-	NanReturnValue(NanUndefined());
+	info.GetReturnValue().Set(Nan::Undefined());
 }
 
 NAN_METHOD(Device_Close) {
@@ -187,17 +190,17 @@ NAN_METHOD(Device_Close) {
 	}else{
 		THROW_ERROR("Can't close device with a pending request");
 	}
-	NanReturnValue(NanUndefined());
+	info.GetReturnValue().Set(Nan::Undefined());
 }
 
 struct Req{
 	uv_work_t req;
 	Device* device;
-	Persistent<Function> callback;
+	Nan::Persistent<Function> callback;
 	int errcode;
 
-	void submit(Device* d, Handle<Function> cb, uv_work_cb backend, uv_work_cb after){
-		NanAssignPersistent(callback, cb);
+	void submit(Device* d, Local<Function> cb, uv_work_cb backend, uv_work_cb after){
+		callback.Reset(cb);
 		device = d;
 		device->ref();
 		req.data = this;
@@ -205,24 +208,24 @@ struct Req{
 	}
 
 	static void default_after(uv_work_t *req){
-		NanScope();
+		Nan::HandleScope scope;
 		auto baton = (Req*) req->data;
 
-		auto device = NanObjectWrapHandle(baton->device);
+		auto device = baton->device->handle();
 		baton->device->unref();
 
-		if (!NanNew(baton->callback).IsEmpty()) {
-			Handle<Value> error = NanUndefined();
+		if (!Nan::New(baton->callback).IsEmpty()) {
+			Local<Value> error = Nan::Undefined();
 			if (baton->errcode < 0){
 				error = libusbException(baton->errcode);
 			}
-			Handle<Value> argv[1] = {error};
-			TryCatch try_catch;
-			NanMakeCallback(device, NanNew(baton->callback), 1, argv);
+			Local<Value> argv[1] = {error};
+			Nan::TryCatch try_catch;
+			Nan::MakeCallback(device, Nan::New(baton->callback), 1, argv);
 			if (try_catch.HasCaught()) {
-				FatalException(try_catch);
+				Nan::FatalException(try_catch);
 			}
-			NanDisposePersistent(baton->callback);
+			baton->callback.Reset();
 		}
 		delete baton;
 	}
@@ -235,7 +238,7 @@ struct Device_Reset: Req{
 		CALLBACK_ARG(0);
 		auto baton = new Device_Reset;
 		baton->submit(self, callback, &backend, &default_after);
-		NanReturnValue(NanUndefined());
+		info.GetReturnValue().Set(Nan::Undefined());
 	}
 
 	static void backend(uv_work_t *req){
@@ -251,7 +254,7 @@ NAN_METHOD(IsKernelDriverActive) {
 	INT_ARG(interface, 0);
 	int r = libusb_kernel_driver_active(self->device_handle, interface);
 	CHECK_USB(r);
-	NanReturnValue(NanNew<Boolean>(r));
+	info.GetReturnValue().Set(Nan::New<Boolean>(r));
 }
 
 NAN_METHOD(DetachKernelDriver) {
@@ -260,7 +263,7 @@ NAN_METHOD(DetachKernelDriver) {
 	int interface;
 	INT_ARG(interface, 0);
 	CHECK_USB(libusb_detach_kernel_driver(self->device_handle, interface));
-	NanReturnValue(NanUndefined());
+	info.GetReturnValue().Set(Nan::Undefined());
 }
 
 NAN_METHOD(AttachKernelDriver) {
@@ -269,7 +272,7 @@ NAN_METHOD(AttachKernelDriver) {
 	int interface;
 	INT_ARG(interface, 0);
 	CHECK_USB(libusb_attach_kernel_driver(self->device_handle, interface));
-	NanReturnValue(NanUndefined());
+	info.GetReturnValue().Set(Nan::Undefined());
 }
 
 NAN_METHOD(Device_ClaimInterface) {
@@ -278,7 +281,7 @@ NAN_METHOD(Device_ClaimInterface) {
 	int interface;
 	INT_ARG(interface, 0);
 	CHECK_USB(libusb_claim_interface(self->device_handle, interface));
-	NanReturnValue(NanUndefined());
+	info.GetReturnValue().Set(Nan::Undefined());
 }
 
 struct Device_ReleaseInterface: Req{
@@ -294,7 +297,7 @@ struct Device_ReleaseInterface: Req{
 		baton->interface = interface;
 		baton->submit(self, callback, &backend, &default_after);
 
-		NanReturnValue(NanUndefined());
+		info.GetReturnValue().Set(Nan::Undefined());
 	}
 
 	static void backend(uv_work_t *req){
@@ -318,7 +321,7 @@ struct Device_SetInterface: Req{
 		baton->interface = interface;
 		baton->altsetting = altsetting;
 		baton->submit(self, callback, &backend, &default_after);
-		NanReturnValue(NanUndefined());
+		info.GetReturnValue().Set(Nan::Undefined());
 	}
 
 	static void backend(uv_work_t *req){
@@ -328,24 +331,24 @@ struct Device_SetInterface: Req{
 	}
 };
 
-void Device::Init(Handle<Object> target){
-	Local<FunctionTemplate> tpl = NanNew<FunctionTemplate>(deviceConstructor);
-	tpl->SetClassName(NanNew("Device"));
+void Device::Init(Local<Object> target){
+	Local<FunctionTemplate> tpl = Nan::New<FunctionTemplate>(deviceConstructor);
+	tpl->SetClassName(Nan::New("Device").ToLocalChecked());
 	tpl->InstanceTemplate()->SetInternalFieldCount(1);
 
-	NODE_SET_PROTOTYPE_METHOD(tpl, "__getConfigDescriptor", Device_GetConfigDescriptor);
-	NODE_SET_PROTOTYPE_METHOD(tpl, "__open", Device_Open);
-	NODE_SET_PROTOTYPE_METHOD(tpl, "__close", Device_Close);
-	NODE_SET_PROTOTYPE_METHOD(tpl, "reset", Device_Reset::begin);
+	Nan::SetPrototypeMethod(tpl, "__getConfigDescriptor", Device_GetConfigDescriptor);
+	Nan::SetPrototypeMethod(tpl, "__open", Device_Open);
+	Nan::SetPrototypeMethod(tpl, "__close", Device_Close);
+	Nan::SetPrototypeMethod(tpl, "reset", Device_Reset::begin);
 
-	NODE_SET_PROTOTYPE_METHOD(tpl, "__claimInterface", Device_ClaimInterface);
-	NODE_SET_PROTOTYPE_METHOD(tpl, "__releaseInterface", Device_ReleaseInterface::begin);
-	NODE_SET_PROTOTYPE_METHOD(tpl, "__setInterface", Device_SetInterface::begin);
+	Nan::SetPrototypeMethod(tpl, "__claimInterface", Device_ClaimInterface);
+	Nan::SetPrototypeMethod(tpl, "__releaseInterface", Device_ReleaseInterface::begin);
+	Nan::SetPrototypeMethod(tpl, "__setInterface", Device_SetInterface::begin);
 
-	NODE_SET_PROTOTYPE_METHOD(tpl, "__isKernelDriverActive", IsKernelDriverActive);
-	NODE_SET_PROTOTYPE_METHOD(tpl, "__detachKernelDriver", DetachKernelDriver);
-	NODE_SET_PROTOTYPE_METHOD(tpl, "__attachKernelDriver", AttachKernelDriver);
+	Nan::SetPrototypeMethod(tpl, "__isKernelDriverActive", IsKernelDriverActive);
+	Nan::SetPrototypeMethod(tpl, "__detachKernelDriver", DetachKernelDriver);
+	Nan::SetPrototypeMethod(tpl, "__attachKernelDriver", AttachKernelDriver);
 
-	NanAssignPersistent(device_constructor, tpl);
-	target->Set(NanNew("Device"), tpl->GetFunction());
+	device_constructor.Reset(tpl);
+	target->Set(Nan::New("Device").ToLocalChecked(), tpl->GetFunction());
 }

--- a/src/helpers.h
+++ b/src/helpers.h
@@ -5,70 +5,70 @@
 
 using namespace v8;
 
-#define V8STR(str) NanNew<String>(str)
-#define V8SYM(str) NanNew<String>(str)
+#define V8STR(str) Nan::New<String>(str).ToLocalChecked()
+#define V8SYM(str) Nan::New<String>(str).ToLocalChecked()
 
-#define THROW_BAD_ARGS(FAIL_MSG) return NanThrowTypeError(FAIL_MSG);
-#define THROW_ERROR(FAIL_MSG) return NanThrowError(FAIL_MSG);
-#define CHECK_N_ARGS(MIN_ARGS) if (args.Length() < MIN_ARGS) { THROW_BAD_ARGS("Expected " #MIN_ARGS " arguments") }
+#define THROW_BAD_ARGS(FAIL_MSG) return Nan::ThrowTypeError(FAIL_MSG);
+#define THROW_ERROR(FAIL_MSG) return Nan::ThrowError(FAIL_MSG);
+#define CHECK_N_ARGS(MIN_ARGS) if (info.Length() < MIN_ARGS) { THROW_BAD_ARGS("Expected " #MIN_ARGS " arguments") }
 
 const PropertyAttribute CONST_PROP = static_cast<PropertyAttribute>(ReadOnly|DontDelete);
 
 inline static void setConst(Handle<Object> obj, const char* const name, Handle<Value> value){
-	obj->ForceSet(NanNew<String>(name), value, CONST_PROP);
+	obj->ForceSet(Nan::New<String>(name).ToLocalChecked(), value, CONST_PROP);
 }
 
 #define ENTER_CONSTRUCTOR(MIN_ARGS) \
-	NanScope();              \
-	if (!args.IsConstructCall()) return NanThrowError("Must be called with `new`!"); \
+	Nan::HandleScope scope;              \
+	if (!info.IsConstructCall()) return Nan::ThrowError("Must be called with `new`!"); \
 	CHECK_N_ARGS(MIN_ARGS);
 
 #define ENTER_CONSTRUCTOR_POINTER(CLASS, MIN_ARGS) \
 	ENTER_CONSTRUCTOR(MIN_ARGS)                    \
-	if (!args.Length() || !args[0]->IsExternal()){ \
-		return NanThrowError("This type cannot be created directly!"); \
+	if (!info.Length() || !info[0]->IsExternal()){ \
+		return Nan::ThrowError("This type cannot be created directly!"); \
 	}                                               \
-	auto self = static_cast<CLASS*>(External::Cast(*args[0])->Value()); \
-	self->attach(args.This())
+	auto self = static_cast<CLASS*>(External::Cast(*info[0])->Value()); \
+	self->attach(info.This())
 
 #define ENTER_METHOD(CLASS, MIN_ARGS) \
-	NanScope();                \
+	Nan::HandleScope scope;                \
 	CHECK_N_ARGS(MIN_ARGS);           \
-	auto self = node::ObjectWrap::Unwrap<CLASS>(args.This()); \
+	auto self = Nan::ObjectWrap::Unwrap<CLASS>(info.This()); \
 	if (self == NULL) { THROW_BAD_ARGS(#CLASS " method called on invalid object") }
 
 #define ENTER_ACCESSOR(CLASS) \
-		NanScope();                \
-		auto self = node::ObjectWrap::Unwrap<CLASS>(info.Holder());
+		Nan::HandleScope scope;                \
+		auto self = Nan::ObjectWrap::Unwrap<CLASS>(info.Holder());
 
 #define UNWRAP_ARG(CLASS, NAME, ARGNO)     \
-	if (!args[ARGNO]->IsObject())          \
+	if (!info[ARGNO]->IsObject())          \
 		THROW_BAD_ARGS("Parameter " #NAME " is not an object"); \
-	auto NAME = node::ObjectWrap::Unwrap<CLASS>(Handle<Object>::Cast(args[ARGNO])); \
+	auto NAME = Nan::ObjectWrap::Unwrap<CLASS>(Handle<Object>::Cast(info[ARGNO])); \
 	if (!NAME)                             \
 		THROW_BAD_ARGS("Parameter " #NAME " (" #ARGNO ") is of incorrect type");
 
 #define STRING_ARG(NAME, N) \
-	if (args.Length() > N){ \
-		if (!args[N]->IsString()) \
+	if (info.Length() > N){ \
+		if (!info[N]->IsString()) \
 			THROW_BAD_ARGS("Parameter " #NAME " (" #N ") should be string"); \
-		NAME = *String::Utf8Value(args[N]->ToString()); \
+		NAME = *String::Utf8Value(info[N]->ToString()); \
 	}
 
 #define DOUBLE_ARG(NAME, N) \
-	if (!args[N]->IsNumber()) \
+	if (!info[N]->IsNumber()) \
 		THROW_BAD_ARGS("Parameter " #NAME " (" #N ") should be number"); \
-	NAME = args[N]->ToNumber()->Value();
+	NAME = info[N]->ToNumber()->Value();
 
 #define INT_ARG(NAME, N) \
-	if (!args[N]->IsNumber()) \
+	if (!info[N]->IsNumber()) \
 		THROW_BAD_ARGS("Parameter " #NAME " (" #N ") should be number"); \
-	NAME = args[N]->ToInt32()->Value();
+	NAME = info[N]->ToInt32()->Value();
 
 #define BOOL_ARG(NAME, N) \
 	NAME = false;    \
-	if (args.Length() > N){ \
-		if (!args[N]->IsBoolean()) \
+	if (info.Length() > N){ \
+		if (!info[N]->IsBoolean()) \
 			THROW_BAD_ARGS("Parameter " #NAME " (" #N ") should be bool"); \
-		NAME = args[N]->ToBoolean()->Value(); \
+		NAME = info[N]->ToBoolean()->Value(); \
 	}

--- a/src/node_usb.h
+++ b/src/node_usb.h
@@ -22,39 +22,44 @@ using namespace node;
 
 Local<Value> libusbException(int errorno);
 
+struct DeviceObject {
+	Nan::Persistent<Object> obj;
+};
 
-struct Device: public node::ObjectWrap {
+struct Device: public Nan::ObjectWrap {
 	libusb_device* device;
 	libusb_device_handle* device_handle;
 
-	static void Init(Handle<Object> exports);
-	static Handle<Value> get(libusb_device* handle);
+	static void Init(Local<Object> exports);
+	static Local<Object> get(libusb_device* handle);
 
 	inline void ref(){Ref();}
 	inline void unref(){Unref();}
 	inline bool canClose(){return refs_ == 0;}
-	inline void attach(Handle<Object> o){Wrap(o);}
+	inline void attach(Local<Object> o){Wrap(o);}
 
 	~Device();
 	static void unpin(libusb_device* device);
 
 	protected:
-		static std::map<libusb_device*, _NanWeakCallbackInfo<Value, libusb_device>*> byPtr;
+		// static std::map<libusb_device*, WeakCallbackInfo<libusb_device>*> byPtr;
+		// static std::map<libusb_device*, Persistent<Value>*> byPtr;
+		static std::map<libusb_device*, DeviceObject*> byPtr;
 		Device(libusb_device* d);
 };
 
 
-struct Transfer: public node::ObjectWrap {
+struct Transfer: public Nan::ObjectWrap {
 	libusb_transfer* transfer;
 	Device* device;
-	Persistent<Object> v8buffer;
-	Persistent<Function> v8callback;
+	Nan::Persistent<Object> v8buffer;
+	Nan::Persistent<Function> v8callback;
 
-	static void Init(Handle<Object> exports);
+	static void Init(Local<Object> exports);
 
 	inline void ref(){Ref();}
 	inline void unref(){Unref();}
-	inline void attach(Handle<Object> o){Wrap(o);}
+	inline void attach(Local<Object> o){Wrap(o);}
 
 	Transfer();
 	~Transfer();
@@ -64,16 +69,16 @@ struct Transfer: public node::ObjectWrap {
 
 #define CHECK_USB(r) \
 	if (r < LIBUSB_SUCCESS) { \
-		return NanThrowError(libusbException(r)); \
+		return Nan::ThrowError(libusbException(r)); \
 	}
 
 #define CALLBACK_ARG(CALLBACK_ARG_IDX) \
 	Local<Function> callback; \
-	if (args.Length() > (CALLBACK_ARG_IDX)) { \
-		if (!args[CALLBACK_ARG_IDX]->IsFunction()) { \
-			return NanThrowTypeError("Argument " #CALLBACK_ARG_IDX " must be a function"); \
+	if (info.Length() > (CALLBACK_ARG_IDX)) { \
+		if (!info[CALLBACK_ARG_IDX]->IsFunction()) { \
+			return Nan::ThrowTypeError("Argument " #CALLBACK_ARG_IDX " must be a function"); \
 		} \
-		callback = Local<Function>::Cast(args[CALLBACK_ARG_IDX]); \
+		callback = Local<Function>::Cast(info[CALLBACK_ARG_IDX]); \
 	} \
 
 #ifdef DEBUG

--- a/usb.js
+++ b/usb.js
@@ -29,8 +29,9 @@ exports.findByIds = function(vid, pid) {
 
 usb.Device.prototype.timeout = 1000
 
-usb.Device.prototype.open = function(){
+usb.Device.prototype.open = function(defaultConfig){
 	this.__open()
+	if (defaultConfig === false) return
 	this.interfaces = []
 	var len = this.configDescriptor.interfaces.length
 	for (var i=0; i<len; i++){
@@ -128,6 +129,20 @@ usb.Device.prototype.getStringDescriptor = function (desc_index, callback) {
 			callback(undefined, buf.toString('utf16le', 2));
 		}
 	);
+}
+
+usb.Device.prototype.setConfiguration = function(desired, cb) {
+	var self = this;
+	this.__setConfiguration(desired, function(err) {
+		if (!err) {
+			this.interfaces = []
+			var len = this.configDescriptor.interfaces.length
+			for (var i=0; i<len; i++) {
+				this.interfaces[i] = new Interface(this, i)
+			}
+		}
+		cb.call(self, err)
+	});
 }
 
 function Interface(device, id){


### PR DESCRIPTION
I have a usb random number generator and it requires that set_configurtion is both called before the config descriptor (obviously). it's a pretty minimal change. (only caveat is if you're gonna configure with a predefined device config, open should be called with false.)


it's mentioned in the readme only initial configurations are supported, ... well here it is if anyone needs it.