### PR TITLE
Adds io.js-complete builds of Win 32, 64, and OS X.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,6 @@
+environment:
+  GYP_MSVS_VERSION: 2013
+
 install:
   - ps: Install-Product node 0.10 $env:platform
   - npm install -g node-gyp

--- a/package.json
+++ b/package.json
@@ -26,9 +26,9 @@
   ],
   "version": "1.0.4",
   "optionalDependencies": {
-    "usb-shyp-win32-x64": "1.0.4",
-    "usb-shyp-win32-ia32": "1.0.4",
-    "usb-shyp-darwin-x64": "1.0.4"
+    "usb-shyp-win32-x64": "1.0.5",
+    "usb-shyp-win32-ia32": "1.0.5",
+    "usb-shyp-darwin-x64": "1.0.6"
   },
   "engines": {
     "node": ">=0.8.x"


### PR DESCRIPTION
The prior builds did not contain io.js bindings in them.