### PR TITLE
try catch on transfer cancel

### DIFF
--- a/usb.js
+++ b/usb.js
@@ -256,7 +256,11 @@ Endpoint.prototype.stopPoll = function(cb){
 		throw new Error('Polling is not active.');
 	}
 	for (var i=0; i<this.pollTransfers.length; i++){
-		this.pollTransfers[i].cancel()
+		try {
+			this.pollTransfers[i].cancel()
+		} catch (err) {
+			this.emit('error', err);
+		}
 	}
 	this.pollActive = false
 	if (cb) this.once('end', cb);


### PR DESCRIPTION
Catches and emits errors from InEndpoint transfer canceling.

Previously this would occur:
```
this.pollTransfers[i].cancel()
                                              ^
Error: LIBUSB_ERROR_OTHER
    at Error (native)
    at InEndpoint.Endpoint.stopPoll (/Users/jia/projects/technical/v2/t2-test-rig-sw/client/node_modules/usb/usb.js:261:26)
    at Transfer.transferDone (/Users/jia/projects/technical/v2/t2-test-rig-sw/client/node_modules/usb/usb.js:304:9)
```