### PR TITLE
libusb on linux kernel 4+ advice

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -12,7 +12,7 @@ It's based entirely on libusb's asynchronous API for better efficiency, and prov
 Installation
 ============
 
-Libusb is included as a submodule. On Linux, you'll need libudev to build libusb. On Ubuntu/Debian: `sudo apt-get install build-essential libudev-dev`
+Libusb is included as a submodule. On Linux, you'll need libudev to build libusb. With Kernel v4+, symlink `/dev/bus` to its new location, `/sys/bus` to work with libusb. On Ubuntu/Debian: `sudo apt-get install build-essential libudev-dev`
 
 Then, just run
 


### PR DESCRIPTION
@tcr, I'm having to do: 

```sh
$ sudo ln -s /sys/bus /dev/bus
``` 

to get libusb and node-usb to work w/ more recent linux kernels. This PR makes a note of the change.